### PR TITLE
Enhance evaluation output with token and entity accuracy

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,9 +9,37 @@ from data import loader
 from data.dataset import collate_fn
 from model.model import MyModel
 from utils import seed_worker, seed_everything, train, evaluate
+import constants
 import warnings
 warnings.filterwarnings("ignore", category=FutureWarning)
 os.environ['KMP_DUPLICATE_LIB_OK'] = 'TRUE'
+
+
+def print_entity_statistics(entity_correct_counts, entity_total_counts):
+    entity_types = sorted({label.split('-', 1)[1] for label in constants.ID_TO_LABEL if '-' in label} |
+                          set(entity_correct_counts.keys()) |
+                          set(entity_total_counts.keys()))
+
+    if not entity_types:
+        print('各实体类别正确数量与总数量：无实体样本')
+        print('实体类别 Accuracy：无实体样本')
+        return
+
+    print('各实体类别正确数量与总数量：')
+    for entity_type in entity_types:
+        total = entity_total_counts.get(entity_type, 0)
+        correct = entity_correct_counts.get(entity_type, 0)
+        print(f'{entity_type}: 正确 {correct} 个，总数 {total} 个')
+
+    print('实体类别 Accuracy：')
+    for entity_type in entity_types:
+        total = entity_total_counts.get(entity_type, 0)
+        correct = entity_correct_counts.get(entity_type, 0)
+        if total > 0:
+            accuracy = correct / total
+            print(f'实体类别 {entity_type} Accuracy= {correct}/{total} = {accuracy:.4f}')
+        else:
+            print(f'实体类别 {entity_type} Accuracy= 无测试样本')
 
 def main():
     parser = argparse.ArgumentParser()
@@ -92,9 +120,23 @@ def main():
     if args.load_model:
         state = torch.load(args.load_model, map_location=model.device)
         model.load_state_dict(state)
-        test_f1, test_report, test_total, test_correct, test_wrong, tokens, preds, trues = evaluate(model, ner_test_loader, return_preds=True)
+        (
+            test_f1,
+            test_report,
+            test_total,
+            test_correct,
+            test_wrong,
+            test_entity_correct_counts,
+            test_entity_total_counts,
+            tokens,
+            preds,
+            trues,
+        ) = evaluate(model, ner_test_loader, return_preds=True)
         print(f'f1 score on test set: {test_f1:.4f}')
-        print(f'测试集共 {test_total} 个数据，预测正确 {test_correct} 个，预测错误 {test_wrong} 个')
+        print(f'测试集共 {test_total} 个 token，预测正确 {test_correct} 个，预测错误 {test_wrong} 个')
+        print(f'Token Accuracy: {test_correct}/{test_total} = {test_correct / test_total:.15f}')
+        print()
+        print_entity_statistics(test_entity_correct_counts, test_entity_total_counts)
         print()
         print(test_report)
         save_result('test', tokens, preds, trues)
@@ -125,6 +167,8 @@ def main():
     ner_losses, itr_losses = [], []
     best_dev_f1, best_test_f1, best_test_report = 0, 0, None
     best_total = best_correct = best_wrong = 0
+    best_entity_correct = {}
+    best_entity_total = {}
     for epoch in range(1, args.num_epochs + 1):
         if args.aux:
             itr_loss = train(itr_train_loader, model, optimizer, task='itr', weight=0.05)
@@ -135,12 +179,21 @@ def main():
         ner_losses.append(ner_loss)
         print(f'loss of multimodal named entity recognition at epoch#{epoch}: {ner_loss:.2f}')
 
-        dev_f1, dev_report, _, _, _ = evaluate(model, ner_dev_loader)
+        dev_f1, dev_report, _, _, _, _, _ = evaluate(model, ner_dev_loader)
         dev_f1s.append(dev_f1)
-        test_f1, test_report, test_total, test_correct, test_wrong = evaluate(model, ner_test_loader)
+        (
+            test_f1,
+            test_report,
+            test_total,
+            test_correct,
+            test_wrong,
+            test_entity_correct_counts,
+            test_entity_total_counts,
+        ) = evaluate(model, ner_test_loader)
         test_f1s.append(test_f1)
         print(f'f1 score on dev set: {dev_f1:.4f}, f1 score on test set: {test_f1:.4f}')
-        print(f'测试集共 {test_total} 个数据，预测正确 {test_correct} 个，预测错误 {test_wrong} 个')
+        print(f'测试集共 {test_total} 个 token，预测正确 {test_correct} 个，预测错误 {test_wrong} 个')
+        print(f'Token Accuracy: {test_correct}/{test_total} = {test_correct / test_total:.15f}')
         if dev_f1 > best_dev_f1:
             best_dev_f1 = dev_f1
             best_test_f1 = test_f1
@@ -148,6 +201,8 @@ def main():
             best_total = test_total
             best_correct = test_correct
             best_wrong = test_wrong
+            best_entity_correct = dict(test_entity_correct_counts)
+            best_entity_total = dict(test_entity_total_counts)
             torch.save(model.state_dict(), os.path.join(args.ckpt_dir, 'best_model.pt'))
 
         if args.save_interval > 0 and epoch % args.save_interval == 0:
@@ -155,11 +210,17 @@ def main():
 
     print()
     print(f'f1 score on dev set: {best_dev_f1:.4f}, f1 score on test set: {best_test_f1:.4f}')
-    print(f'测试集共 {best_total} 个数据，预测正确 {best_correct} 个，预测错误 {best_wrong} 个')
+    print(f'测试集共 {best_total} 个 token，预测正确 {best_correct} 个，预测错误 {best_wrong} 个')
+    if best_total > 0:
+        print(f'Token Accuracy: {best_correct}/{best_total} = {best_correct / best_total:.15f}')
+    else:
+        print('Token Accuracy: 无测试样本')
+    print()
+    print_entity_statistics(best_entity_correct, best_entity_total)
     print()
     print(best_test_report)
 
-    _, _, _, _, _, train_tokens, train_preds, train_trues = evaluate(model, ner_train_loader, return_preds=True)
+    _, _, _, _, _, _, _, train_tokens, train_preds, train_trues = evaluate(model, ner_train_loader, return_preds=True)
     save_result('train', train_tokens, train_preds, train_trues)
 
     results = {


### PR DESCRIPTION
## Summary
- add a helper to print entity-level totals and accuracy alongside evaluation output
- include token accuracy messaging when reporting test metrics
- extend `evaluate` to compute per-entity correct and total counts for reuse in reporting

## Testing
- python -m compileall main.py utils.py

------
https://chatgpt.com/codex/tasks/task_e_68ccfa9e6ab08325a2b00f8e32732d30